### PR TITLE
Fix footer date (year)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,5 +6,5 @@
         <li><a href="/feeds/feed.xml" title="Flux RSS">RSS</a></li>
         <li><a href="http://twitter.com/HugoGiraudel" title="Hugo on Twitter" target="blank">Twitter</a></li>
     </ul>
-    <p>&copy;&nbsp;{{ 'now' | date: "%Y" }} Hugo Giraudel. Built on <a href="http://jekyllrb.com/">Jekyll</a> and <a href="http://sass-lang.com/">Sass</a>. Hosted on <a href="https://github.com/HugoGiraudel/hugogiraudel.github.com">GitHub</a>.</p> 
+    <p>&copy;&nbsp;{{ site.time | date: '%Y' }} Hugo Giraudel. Built on <a href="http://jekyllrb.com/">Jekyll</a> and <a href="http://sass-lang.com/">Sass</a>. Hosted on <a href="https://github.com/HugoGiraudel/hugogiraudel.github.com">GitHub</a>.</p>
 </footer>


### PR DESCRIPTION
Hey Hugo,

Seems like there's a bug with Ruby version used by GitHub Pages and the `{{ 'now' | date: '%y' }}` .

Use `{{ site.time | date: '%Y' }}` to fix this issue.

Hope that could be useful!

Keep doing your awesome work!
