### PR TITLE
Fix link to RSS feed in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
 
       <div class="Footer__right">
         <ul class="Footer__list">
-          <li><a href="/rss">RSS</a></li>
+          <li><a href="/rss/index.xml">RSS</a></li>
           <li><a href="https://twitter.com/KittyGiraudel">Twitter</a></li>
           <li><a href="https://github.com/KittyGiraudel">GitHub</a></li>
           <li><a href="/resume">Resume</a></li>


### PR DESCRIPTION
The old URL was a 404 🙂 